### PR TITLE
fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ to set a boilerplate/template for future work or to play around with.
 
 To install:
 ``` bash
-$ npm intall
+$ npm install
 $ npm run dev
 ```
 


### PR DESCRIPTION
I found a typo in README. It was 'npm intall' instead of 'npm install'. 